### PR TITLE
OPC-DA: Browse available tags #66

### DIFF
--- a/historian/backend/pom.xml
+++ b/historian/backend/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.github.Hurence</groupId>
             <artifactId>opc-simple</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
 
         <dependency>

--- a/historian/backend/pom.xml
+++ b/historian/backend/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.github.Hurence</groupId>
             <artifactId>opc-simple</artifactId>
-            <version>15ea757262</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>

--- a/historian/backend/src/main/java/com/hurence/logisland/historian/repository/OpcRepository.java
+++ b/historian/backend/src/main/java/com/hurence/logisland/historian/repository/OpcRepository.java
@@ -17,6 +17,7 @@
 
 package com.hurence.logisland.historian.repository;
 
+import com.hurence.opc.OpcTagInfo;
 import com.hurence.opc.da.OpcDaConnectionProfile;
 import com.hurence.opc.da.OpcDaOperations;
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ public class OpcRepository {
      * @param connectionProfile the connection information.
      * @return a never empty {@link Collection}
      */
-    public Collection<String> fetchAllTags(@Valid OpcDaConnectionProfile connectionProfile) {
+    public Collection<OpcTagInfo> fetchAllTags(@Valid OpcDaConnectionProfile connectionProfile) {
         OpcDaOperations opcDaOperations = new OpcDaOperations();
         try {
             opcDaOperations.connect(connectionProfile);


### PR DESCRIPTION
- Upgrade opc-simple to 1.1.0.
- Integrate OPC data type information in TAG browse API.