### PR TITLE
Datasources aggregated health status indicator #92

### DIFF
--- a/historian/backend/src/main/java/com/hurence/logisland/historian/dictionary/DatasourceTypes.java
+++ b/historian/backend/src/main/java/com/hurence/logisland/historian/dictionary/DatasourceTypes.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.historian.dictionary;
+
+public interface DatasourceTypes {
+
+    String OPC_DA_TYPE = "OPC-DA";
+}

--- a/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/DatasourceHealthChecker.java
+++ b/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/DatasourceHealthChecker.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.historian.service.health;
+
+import com.hurence.logisland.historian.rest.v1.model.Datasource;
+import org.springframework.boot.actuate.health.Health;
+
+/**
+ * Api interface to check for a {@link Datasource} health.
+ *
+ * @author amarziali
+ */
+@FunctionalInterface
+public interface DatasourceHealthChecker {
+
+    /**
+     * Checks for health.
+     * @param datasource the datasource to check.
+     * @return an actuator {@link Health} information (never null).
+     */
+    Health doHealthCheck(Datasource datasource);
+}

--- a/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/HistorianDatasourceHealthIndicator.java
+++ b/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/HistorianDatasourceHealthIndicator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.historian.service.health;
+
+import com.hurence.logisland.historian.dictionary.DatasourceTypes;
+import com.hurence.logisland.historian.rest.v1.model.Datasource;
+import com.hurence.logisland.historian.service.DatasourcesApiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Health reporter for datasource objects.
+ *
+ * @author amarziali
+ */
+@Service
+public class HistorianDatasourceHealthIndicator extends AbstractHealthIndicator {
+
+    private final static Logger logger = LoggerFactory.getLogger(HistorianDatasourceHealthIndicator.class);
+    private final static DatasourceHealthChecker unknownDatasourceChecker = (ds -> Health.unknown().build());
+    private final static OpcDaDatasourceHealthChecker opcDaDatasourceChecker = new OpcDaDatasourceHealthChecker();
+
+    @Autowired
+    private DatasourcesApiService datasourcesApiService;
+
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+        Map<String, Health> healthMap = datasourcesApiService.getAllDatasources(null)
+                .stream()
+                .collect(Collectors.toMap(Datasource::getId, this::healthCheckFor));
+
+        boolean isDown = healthMap.values().stream().anyMatch(health -> !Status.UP.equals(health.getStatus()));
+        if (isDown) {
+            builder.down();
+        } else {
+            builder.up();
+        }
+        healthMap.forEach((id, health) -> {
+            builder.withDetail(id, health);
+        });
+
+    }
+
+    private Health healthCheckFor(Datasource ds) {
+        try {
+            return healthCheckerFor(ds).doHealthCheck(ds);
+        } catch (Exception e) {
+            logger.error("Exception occurred while checking health for datasource " + ds.getId(), e);
+            return Health.down(e).build();
+        }
+    }
+
+    private DatasourceHealthChecker healthCheckerFor(Datasource datasource) {
+        if (datasource == null || datasource.getDatasourceType() == null) {
+            logger.error("Datasource or its type cannot be null");
+            return unknownDatasourceChecker;
+        }
+        String datasourceType = datasource.getDatasourceType();
+        if (datasourceType.equals(DatasourceTypes.OPC_DA_TYPE)) {
+            return opcDaDatasourceChecker;
+        } else {
+            logger.warn("Unhandled datasource type {}", datasourceType);
+            return unknownDatasourceChecker;
+        }
+
+    }
+}

--- a/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/OpcDaDatasourceHealthChecker.java
+++ b/historian/backend/src/main/java/com/hurence/logisland/historian/service/health/OpcDaDatasourceHealthChecker.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Hurence (support@hurence.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hurence.logisland.historian.service.health;
+
+import com.hurence.logisland.historian.dictionary.DatasourceTypes;
+import com.hurence.logisland.historian.rest.v1.model.Datasource;
+import com.hurence.opc.da.OpcDaConnectionProfile;
+import com.hurence.opc.da.OpcDaOperations;
+import org.springframework.boot.actuate.health.Health;
+
+import java.time.Duration;
+
+/**
+ * OPC-DA datasource health checker.
+ *
+ * @author amarziali
+ */
+public class OpcDaDatasourceHealthChecker implements DatasourceHealthChecker {
+
+    @Override
+    public Health doHealthCheck(Datasource datasource) {
+        if (datasource == null || !DatasourceTypes.OPC_DA_TYPE.equals(datasource.getDatasourceType())) {
+            throw new IllegalArgumentException("Datasource is undefined or  type is not supported");
+        }
+        String hostParts[] = datasource.getHost().split(":");
+        OpcDaConnectionProfile connectionProfile = new OpcDaConnectionProfile()
+                .withSocketTimeout(Duration.ofSeconds(2))
+                .withPassword(datasource.getPassword())
+                .withHost(hostParts[0])
+                .withDomain(datasource.getDomain())
+                .withUser(datasource.getUser())
+                .withComClsId(datasource.getClsid())
+                .withComProgId(datasource.getProgId());
+        if (hostParts.length > 1) {
+            connectionProfile.setPort(Integer.parseInt(hostParts[1]));
+        }
+
+        try (OpcDaOperations opcDaOperations = new OpcDaOperations()) {
+            opcDaOperations.connect(connectionProfile);
+            if (opcDaOperations.awaitConnected()) {
+                return Health.up().build();
+            } else {
+                return Health.down().withDetail("error", "Unable to reach datasource").build();
+            }
+
+        } catch (Exception e) {
+            return Health.down(e).build();
+        }
+    }
+}

--- a/historian/backend/src/main/resources/application.yml
+++ b/historian/backend/src/main/resources/application.yml
@@ -72,6 +72,11 @@ management:
     web:
       exposure:
         include: info, health, metrics
+  endpoint:
+    health:
+      cache:
+        time-to-live: 10s
+      show-details: always
 
 
 


### PR DESCRIPTION
Created aggregated health indicator for datasources. 
Today only OPC-DA type is handled. 

Link to the issue: https://app.zenhub.com/workspace/o/hurence/logisland.historian/issues/92